### PR TITLE
feat: Add WithForceNoNsenter option to bypass nsenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ func run() (err error) {
 }
 ```
 
+## Containerization Support
+
+When running inside a container (e.g., Docker, Kubernetes), `lvm2go` automatically uses `nsenter` to execute LVM commands in the host's mount namespace. This ensures that LVM operations correctly target the host system.
+
+In some advanced scenarios, you might need to execute LVM commands directly within the container's namespace, even if `lvm2go` detects a containerized environment. For this purpose, the `WithForceNoNsenter` context option is provided:
+
+```go
+import (
+	"context"
+	"github.com/azalio/lvm2go"
+)
+
+// ...
+
+// Standard behavior: uses nsenter if containerized
+cmdNormal := lvm2go.CommandContext(ctx, "lvs")
+
+// Force execution without nsenter, even if containerized
+ctxNoNsenter := lvm2go.WithForceNoNsenter(ctx, true)
+cmdNoNsenter := lvm2go.CommandContext(ctxNoNsenter, "lvs")
+```
+
+See the example at [`examples/force_no_nsenter/main.go`](examples/force_no_nsenter/main.go) for more details.
+
 ## Implemented commands by tested feature set
 
 This set of commands is implemented and tested to some extent. The tested feature set is described in the table below.

--- a/examples/force_no_nsenter/main.go
+++ b/examples/force_no_nsenter/main.go
@@ -1,0 +1,74 @@
+/*
+ Copyright 2024 The lvm2go Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/azalio/lvm2go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Check if we're running in a containerized environment
+	isContainerized := lvm2go.IsContainerized(ctx)
+	fmt.Printf("Running in containerized environment: %v\n", isContainerized)
+
+	// Example 1: Standard behavior (uses nsenter if containerized)
+	fmt.Println("\nExample 1: Standard behavior")
+	cmd1 := lvm2go.CommandContext(ctx, "ls", "-l", "/")
+	fmt.Printf("Command path: %s\n", cmd1.Path)
+	fmt.Printf("Command args: %v\n", cmd1.Args)
+
+	// Run the command
+	output1, err := cmd1.CombinedOutput()
+	if err != nil {
+		log.Fatalf("Command failed: %v", err)
+	}
+	fmt.Printf("Command output:\n%s\n", string(output1))
+
+	// Example 2: Force no nsenter, even if containerized
+	fmt.Println("\nExample 2: Force no nsenter")
+	ctxNoNsenter := lvm2go.WithForceNoNsenter(ctx, true)
+	cmd2 := lvm2go.CommandContext(ctxNoNsenter, "ls", "-l", "/")
+	fmt.Printf("Command path: %s\n", cmd2.Path)
+	fmt.Printf("Command args: %v\n", cmd2.Args)
+
+	// Run the command
+	output2, err := cmd2.CombinedOutput()
+	if err != nil {
+		log.Fatalf("Command failed: %v", err)
+	}
+	fmt.Printf("Command output:\n%s\n", string(output2))
+
+	// If we're in a container, the outputs should be different
+	if isContainerized {
+		fmt.Println("\nNote: Since we're in a containerized environment, the outputs should be different:")
+		fmt.Println("- Example 1 shows the host's root directory (via nsenter)")
+		fmt.Println("- Example 2 shows the container's root directory (direct execution)")
+	} else {
+		fmt.Println("\nNote: Since we're not in a containerized environment, both commands executed directly")
+		fmt.Println("and the outputs should be identical.")
+	}
+
+	// Exit with success
+	os.Exit(0)
+}

--- a/nsenter_bypass_plan.md
+++ b/nsenter_bypass_plan.md
@@ -1,0 +1,139 @@
+# Plan to Add a "ForceNoNsenter" Option via Context
+
+This document outlines the plan to add an option to the `lvm2go` library to bypass the `nsenter` execution path when running commands in a containerized environment, even if `IsContainerized(ctx)` returns true. This will be achieved by introducing a new context value.
+
+## 1. Define a new private context key
+
+A new unexported context key will be defined to prevent collisions.
+
+```go
+// In command.go
+var forceNoNsenterKey = struct{}{}
+```
+
+## 2. Create a public "With" function
+
+This function will allow users of the library to create a new context with the "force no nsenter" flag set.
+
+```go
+// In command.go
+func WithForceNoNsenter(ctx context.Context, force bool) context.Context {
+	return context.WithValue(ctx, forceNoNsenterKey, force)
+}
+```
+
+## 3. Create a private "getter" function
+
+This function will be used internally by `CommandContext` to check the value of the flag.
+
+```go
+// In command.go
+func shouldForceNoNsenter(ctx context.Context) bool {
+	if force, ok := ctx.Value(forceNoNsenterKey).(bool); ok {
+		return force
+	}
+	return false // Default to false (i.e., use nsenter if containerized and flag not set)
+}
+```
+
+## 4. Modify the `CommandContext` function
+
+The core logic in `CommandContext` will be updated to check this new context value.
+
+**Current relevant section:**
+
+```go
+// In command.go
+if IsContainerized(ctx) {
+    args = append([]string{"-m", "-u", "-i", "-n", "-p", "-t", "1", cmd}, args...)
+    c = exec.CommandContext(ctx, nsenter, args...)
+} else {
+    c = exec.CommandContext(ctx, cmd, args...)
+}
+```
+
+**Proposed modification:**
+
+```go
+// In command.go
+if IsContainerized(ctx) && !shouldForceNoNsenter(ctx) { // Modified condition
+    args = append([]string{"-m", "-u", "-i", "-n", "-p", "-t", "1", cmd}, args...)
+    c = exec.CommandContext(ctx, nsenter, args...)
+} else {
+    c = exec.CommandContext(ctx, cmd, args...)
+}
+```
+
+## Mermaid Diagram of the Proposed Change
+
+```mermaid
+graph TD
+    A[Your Application] -- Calls --> B(lvm2go.CommandContext)
+    B -- Uses --> C{IsContainerized?}
+    B -- Also Uses --> D{shouldForceNoNsenter?}
+
+    subgraph lvm2go Library
+        direction LR
+        E[lvm2go.WithForceNoNsenter] -- Modifies Context --> F[context.Context with forceNoNsenterKey]
+        B --- F
+        D -- Reads from --> F
+    end
+
+    C -- True --> G{Use nsenter}
+    C -- False --> H[Direct Command]
+
+    D -- True --> H
+    D -- False & C is True --> G
+
+    G --> I[exec.Cmd with nsenter]
+    H --> J[exec.Cmd direct]
+
+    I --> K[Return exec.Cmd]
+    J --> K
+
+    A -- Optionally Calls --> E
+```
+
+## How this would be used in your application
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+
+	"your_module_path/lvm2go" // Assuming lvm2go is in your module
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Example 1: Standard behavior (uses nsenter if containerized)
+	cmd1 := lvm2go.CommandContext(ctx, "ls", "-l", "/")
+	fmt.Println("Cmd1 Path:", cmd1.Path)
+	fmt.Println("Cmd1 Args:", cmd1.Args)
+
+	// Example 2: Force no nsenter, even if containerized
+	ctxNoNsenter := lvm2go.WithForceNoNsenter(ctx, true)
+	cmd2 := lvm2go.CommandContext(ctxNoNsenter, "ls", "-l", "/")
+	fmt.Println("Cmd2 Path:", cmd2.Path) // Will be "ls", not nsenter
+	fmt.Println("Cmd2 Args:", cmd2.Args)
+
+    // Example of running a command (error handling omitted for brevity)
+    output, err := cmd2.CombinedOutput()
+    if err != nil {
+        log.Fatalf("Command failed: %v, Output: %s", err, string(output))
+    }
+    fmt.Printf("Output of cmd2:\n%s\n", string(output))
+}
+
+```
+
+This approach:
+
+* Is non-intrusive to existing users of the library.
+* Provides clear, explicit control for when to bypass `nsenter`.
+* Follows established Go patterns for passing optional parameters.


### PR DESCRIPTION
This PR introduces the `WithForceNoNsenter` context option to allow bypassing `nsenter` when executing LVM commands in a containerized environment.

Changes include:
- Modification to `command.go` to add the new functionality.
- An example in `examples/force_no_nsenter/main.go`.
- Updated `README.md` with documentation for the new feature.
- The planning document `nsenter_bypass_plan.md` is included for context.